### PR TITLE
Dockerfile: add git to fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:slim as builder
 
 RUN apt-get update && \
-    apt-get install gcc -y && \
+    apt-get install gcc git -y && \
     apt-get clean
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
pip tries to fetch bleak by git cloning the repository but git is not installed.
```
Collecting bleak
  Cloning https://github.com/hbldh/bleak.git (to revision f50a334e1173b27a8cf0a53d8ac56d9acc24fedf) to /tmp/pip-install-por745g1/bleak_4279b3234a5a45c1a64670763e19c8df
  ERROR: Error [Errno 2] No such file or directory: 'git' while executing command git clone -q https://github.com/hbldh/bleak.git /tmp/pip-install-por745g1/bleak_4279b3234a5a45c1a64670763e19c8df
ERROR: Cannot find command 'git' - do you have 'git' installed and in your PATH?
WARNING: You are using pip version 20.3.3; however, version 21.0 is available.
You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
The command '/bin/sh -c pip install --user --no-warn-script-location -r requirements.txt' returned a non-zero code: 1
```

Signed-off-by: Nicolae Rosia <nicolae.rosia@gmail.com>