### PR TITLE
Linkquality fixes

### DIFF
--- a/ble2mqtt/utils.py
+++ b/ble2mqtt/utils.py
@@ -1,5 +1,5 @@
 MAX_RSSI = 10
-MIN_RSSI = -87
+MIN_RSSI = -100
 
 
 def format_binary(data: bytes, delimiter=' '):

--- a/ble2mqtt/utils.py
+++ b/ble2mqtt/utils.py
@@ -1,4 +1,4 @@
-MAX_RSSI = 10
+MAX_RSSI = 0
 MIN_RSSI = -100
 
 
@@ -12,4 +12,4 @@ def cr2032_voltage_to_percent(mvolts: int):
 
 
 def rssi_to_linkquality(rssi):
-    return round(255 * (rssi - MIN_RSSI)/(MAX_RSSI-MIN_RSSI))
+    return min(int(round(255 * (rssi - MIN_RSSI) / (MAX_RSSI - MIN_RSSI))), 0)


### PR DESCRIPTION
I did some research and found out, that usually the range of rssi is from -120 to 0. But any values, that lower than -100 is unusable. Therefore, I decided to change the range to -100 to 0 and have tested it a couple of days. Works ok.
https://www.speedcheck.org/wiki/rssi/