### PR TITLE
Docker and x86 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,3 +323,50 @@ ble2mqtt:dev
 Instead of sharing `/var/run/dbus`, you can export `DBUS_SYSTEM_BUS_ADDRESS`.
 
 NOTE: `--net=host` is required as it needs to use the bluetooth interface
+
+NOTE: `podman` is the same as `docker`
+
+
+## Running in Container FULLy
+
+> **ATTENTION:** Make sure `bluez` is not running (or not intalled) on your host. 
+
+Build the image as:
+
+```shell script
+docker build -t ble2mqtt:dev .
+```
+
+Start the container and share the config file:
+```shell script
+docker run \
+-d \
+--net=host \
+--cap-add=NET_ADMIN \
+-v $PWD/ble2mqtt.json.sample:/etc/ble2mqtt.json:ro \
+ble2mqtt:dev
+```
+
+Docker compose:
+``` docker yaml
+version: '3.7'
+services:
+
+  ble2mqtt:
+    image: ble2mqtt:dev
+    build: ./ble2mqtt
+    hostname: ble2mqtt
+    restart: always
+    environment:
+      - TZ=Asia/Yekaterinburg
+    volumes:
+      - ./ble2mqtt/ble2mqtt.json:/etc/ble2mqtt.json:ro
+    network_mode: host
+    cap_add:
+      - NET_ADMIN
+
+```
+
+You do not need sharing `/var/run/dbus`, because `dbus` will start in the container.
+
+NOTE: `--net=host` and `--cap-add=NET_ADMIN` is required as it needs to use and control the bluetooth interface

--- a/ble2mqtt/__main__.py
+++ b/ble2mqtt/__main__.py
@@ -132,7 +132,7 @@ def main():
         **config,
     }
 
-    logging.basicConfig(level=config['log_level'].upper())
+    logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s', level=config['log_level'].upper(), datefmt='%Y-%m-%d %H:%M:%S')
     # logging.getLogger('bleak.backends.bluezdbus.scanner').setLevel('INFO')
     _LOGGER.info(f'Starting BLE2MQTT version {VERSION}')
 

--- a/ble2mqtt/ble2mqtt.py
+++ b/ble2mqtt/ble2mqtt.py
@@ -4,6 +4,7 @@ import logging
 import typing as ty
 from contextlib import asynccontextmanager
 from uuid import getnode
+import os.path
 
 import aio_mqtt
 from bleak import BleakError, BleakScanner
@@ -145,10 +146,22 @@ async def restart_bluetooth():
             'hciconfig', 'hci0', 'down',
         )
         await proc.wait()
-        proc = await aio.create_subprocess_exec(
-            '/etc/init.d/bluetoothd', 'restart',
-        )
-        await proc.wait()
+
+        if os.path.exists('/etc/init.d/bluetoothd'):
+            proc = await aio.create_subprocess_exec(
+                '/etc/init.d/bluetoothd', 'restart',
+            )
+            await proc.wait()
+
+        elif os.path.exists('/etc/init.d/bluetooth'):
+            proc = await aio.create_subprocess_exec(
+                '/etc/init.d/bluetooth', 'restart',
+            )
+            await proc.wait()
+
+        else:
+            _LOGGER.error('init.d bluetoothd script not found')
+
         await aio.sleep(3)
         proc = await aio.create_subprocess_exec(
             'hciconfig', 'hci0', 'up',

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ -f "/var/run/dbus" ]; then
+    ble2mqtt
+else 
+    service dbus start
+    bluetoothd &
+    ble2mqtt
+fi
+


### PR DESCRIPTION
- fix restart bluetooth interface;
- add full run in docker container (x86 support) (without bluez on host);
- add to `readme.md` container fully;
- add time to log;
- change install `ble2mqtt` in container to source; 