### PR TITLE
Fix problem with eol when running docker

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -7,4 +7,3 @@ else
     bluetoothd &
     ble2mqtt
 fi
-


### PR DESCRIPTION
Fix runnig docker_entrypoint.sh:
- Adding .gitattributes
- Change docker_entrypoint.sh eol type to LF