### PR TITLE
ruuvitag: add support for RuuviTag devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 - **Xiaomi LYWSD03MMC with custom ATC firmware (xiaomilywsd_atc)**
   - supported both atc1441 and pvvx formats
 - **Qingping CGDK2 (type: qingpingCGDK2)**
+- **RuuviTag (type: ruuvitag)**
 
 ### Air sensors
 - **Vson WP6003 (type: wp6003)**
@@ -91,6 +92,7 @@ To use connection to the device provide `"passive": false` parameter.
 **Supported devices in passive mode:**
 - Xiaomi MJ_HT_V1 (xiaomihtv1)
 - Xiaomi LYWSD03MMC with custom ATC firmware (xiaomilywsd_atc)
+- RuuviTag (ruuvitag)
 - Any device as presence tracker
 
 ## Manual pairing in Linux

--- a/ble2mqtt/devices/__init__.py
+++ b/ble2mqtt/devices/__init__.py
@@ -10,6 +10,7 @@ from .kettle_redmond import RedmondKettle  # noqa: F401
 from .kettle_xiaomi import XiaomiKettle  # noqa: F401
 from .presence import Presence  # noqa: F401
 from .qingping_cgdk2 import QingpingTempRHMonitorLite  # noqa: F401
+from .ruuvitag import RuuviTag  # noqa: F401
 from .thermostat_ensto import EnstoThermostat  # noqa: F401
 from .voltage_bm2 import VoltageTesterBM2  # noqa: F401
 from .vson_air_wp6003 import VsonWP6003  # noqa: F401

--- a/ble2mqtt/devices/ruuvitag.py
+++ b/ble2mqtt/devices/ruuvitag.py
@@ -1,0 +1,80 @@
+import logging
+from dataclasses import dataclass
+
+from bleak.backends.device import BLEDevice
+
+from ..devices.base import Sensor, SENSOR_DOMAIN, SubscribeAndSetDataMixin
+from ..protocols.ruuvi import RuuviTagDataFormat5Decoder
+from ..utils import format_binary, cr2477t_voltage_to_percent
+
+_LOGGER = logging.getLogger(__name__)
+
+@dataclass
+class SensorState:
+    battery: int = 0
+    temperature: float = 0
+    humidity: float = 0
+    pressure: float = 0
+    movement_counter: int = 0
+
+class RuuviTag(SubscribeAndSetDataMixin, Sensor):
+    NAME = 'ruuvitag'
+    SENSOR_CLASS = SensorState
+    SUPPORT_PASSIVE = True
+    SUPPORT_ACTIVE = False
+    # send data only if temperature or humidity is set
+    REQUIRED_VALUES = ('temperature', 'humidity', 'pressure')
+
+    @property
+    def entities(self):
+        return {
+            SENSOR_DOMAIN: [
+                {
+                    'name': 'temperature',
+                    'device_class': 'temperature',
+                    'unit_of_measurement': '\u00b0C',
+                },
+                {
+                    'name': 'humidity',
+                    'device_class': 'humidity',
+                    'unit_of_measurement': '%',
+                },
+                {
+                    'name': 'pressure',
+                    'device_class': 'atmospheric_pressure',
+                    'unit_of_measurement': 'hPa',
+                },
+                {
+                    'name': 'movement_counter',
+                    'device_class': 'count',
+                },
+                {
+                    'name': 'battery',
+                    'device_class': 'battery',
+                    'entity_category': 'diagnostic',
+                },
+            ],
+        }
+
+    def handle_advert(self, scanned_device: BLEDevice, adv_data):
+        raw_data = adv_data.manufacturer_data[0x0499]
+
+        data_format = raw_data[0]
+        if data_format != 0x05:
+            _LOGGER.debug("Data format not supported: %s", raw_data[0])
+            return
+
+        if raw_data:
+            decoder = RuuviTagDataFormat5Decoder(bytes(raw_data))
+            self._state = self.SENSOR_CLASS(
+                temperature=decoder.temperature_celsius,
+                humidity=decoder.humidity_percentage,
+                pressure=decoder.pressure_hpa,
+                movement_counter=decoder.movement_counter,
+                battery=int(cr2477t_voltage_to_percent(decoder.battery_voltage_mv))
+            )
+
+            _LOGGER.debug(
+                f'Advert received for {self}, {format_binary(raw_data)}, '
+                f'current state: {self._state}',
+            )

--- a/ble2mqtt/protocols/ruuvi.py
+++ b/ble2mqtt/protocols/ruuvi.py
@@ -1,0 +1,80 @@
+"""
+Decoder for RuuviTag Data Format 5 data.
+Based on https://github.com/Bluetooth-Devices/ruuvitag-ble/blob/0e99249/src/ruuvitag_ble/df5_decoder.py (MIT Licensed)
+Which was based on https://github.com/ttu/ruuvitag-sensor/blob/23e6555/ruuvitag_sensor/decoder.py (MIT Licensed)
+"""
+from __future__ import annotations
+
+import math
+import struct
+
+
+class RuuviTagDataFormat5Decoder:
+    def __init__(self, raw_data: bytes) -> None:
+        if len(raw_data) < 24:
+            raise ValueError("Data must be at least 24 bytes long for data format 5")
+        self.data: tuple[int, ...] = struct.unpack(">BhHHhhhHBH6B", raw_data)
+
+    @property
+    def temperature_celsius(self) -> float | None:
+        if self.data[1] == -32768:
+            return None
+        return round(self.data[1] / 200.0, 2)
+
+    @property
+    def humidity_percentage(self) -> float | None:
+        if self.data[2] == 65535:
+            return None
+        return round(self.data[2] / 400, 2)
+
+    @property
+    def pressure_hpa(self) -> float | None:
+        if self.data[3] == 0xFFFF:
+            return None
+
+        return round((self.data[3] + 50000) / 100, 2)
+
+    @property
+    def acceleration_vector_mg(self) -> tuple[int, int, int] | tuple[None, None, None]:
+        ax = self.data[4]
+        ay = self.data[5]
+        az = self.data[6]
+        if ax == -32768 or ay == -32768 or az == -32768:
+            return (None, None, None)
+
+        return (ax, ay, az)
+
+    @property
+    def acceleration_total_mg(self) -> float | None:
+        ax, ay, az = self.acceleration_vector_mg
+        if ax is None or ay is None or az is None:
+            return None
+        return math.sqrt(ax * ax + ay * ay + az * az)
+
+    @property
+    def battery_voltage_mv(self) -> int | None:
+        voltage = self.data[7] >> 5
+        if voltage == 0b11111111111:
+            return None
+
+        return voltage + 1600
+
+    @property
+    def tx_power_dbm(self) -> int | None:
+        tx_power = self.data[7] & 0x001F
+        if tx_power == 0b11111:
+            return None
+
+        return -40 + (tx_power * 2)
+
+    @property
+    def movement_counter(self) -> int:
+        return self.data[8]
+
+    @property
+    def measurement_sequence_number(self) -> int:
+        return self.data[9]
+
+    @property
+    def mac(self) -> str:
+        return ":".join(f"{x:02X}" for x in self.data[10:])

--- a/ble2mqtt/utils.py
+++ b/ble2mqtt/utils.py
@@ -13,6 +13,21 @@ def cr2032_voltage_to_percent(mvolts: int):
     return max(min(int(round((mvolts/1000 - 2.1)/coeff, 2) * 100), 100), 0)
 
 
+def cr2477t_voltage_to_percent(mvolts: int):
+    # Based on https://github.com/custom-components/ble_monitor/blob/18d447a8f/custom_components/ble_monitor/ble_parser/ruuvitag.py#L184-195 (MIT licensed)
+    if mvolts >= 3000:
+        batt = 100
+    elif mvolts >= 2600:
+        batt = 60 + (mvolts - 2600) / 10
+    elif mvolts >= 2500:
+        batt = 40 + (mvolts - 2500) / 5
+    elif mvolts >= 2450:
+        batt = 20 + ((mvolts - 2450) * 2) / 5
+    else:
+        batt = 0
+    return int(round(batt, 1))
+
+
 def rssi_to_linkquality(rssi):
     return max(int(round(255 * (rssi - MIN_RSSI) / (MAX_RSSI - MIN_RSSI))), 0)
 


### PR DESCRIPTION
Only the latest format is supported.

Tested locally:
`2023-09-29 00:49:12 INFO: [Ruuvi_0C58_Sauna_Ruuvi] send state=SensorState(battery=100, temperature=23.89, humidity=59.49, pressure=None, movement_counter=148)`

`$ mosquitto_sub -t ble2mqtt/#
online
{"temperature": 23.89, "humidity": 59.49, "movement_counter": 148, "battery": 100, "linkquality": 97}`

I have a RuuviTag Pro which doesn't support pressure readings so these aren't tested.