### PR TITLE
ruuvitag: only include entities that are available

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@
   - supported both atc1441 and pvvx formats
 - **Qingping CGDK2 (type: qingpingCGDK2)**
 - **RuuviTag (type: ruuvitag)**
+- **RuuviTag Pro 2in1 (type: ruuvitag_pro_2in1)**
+- **RuuviTag Pro 3in1 (type: ruuvitag_pro_3in1)**
+- **RuuviTag Pro 4in1 (type: ruuvitag)**
 
 ### Air sensors
 - **Vson WP6003 (type: wp6003)**
@@ -92,7 +95,7 @@ To use connection to the device provide `"passive": false` parameter.
 **Supported devices in passive mode:**
 - Xiaomi MJ_HT_V1 (xiaomihtv1)
 - Xiaomi LYWSD03MMC with custom ATC firmware (xiaomilywsd_atc)
-- RuuviTag (ruuvitag)
+- RuuviTag (ruuvitag/ruuvitag_pro_2in1/ruuvitag_pro_3in1)
 - Any device as presence tracker
 
 ## Manual pairing in Linux

--- a/ble2mqtt/devices/__init__.py
+++ b/ble2mqtt/devices/__init__.py
@@ -10,7 +10,7 @@ from .kettle_redmond import RedmondKettle  # noqa: F401
 from .kettle_xiaomi import XiaomiKettle  # noqa: F401
 from .presence import Presence  # noqa: F401
 from .qingping_cgdk2 import QingpingTempRHMonitorLite  # noqa: F401
-from .ruuvitag import RuuviTag  # noqa: F401
+from .ruuvitag import RuuviTag, RuuviTagPro2in1, RuuviTagPro3in1  # noqa: F401
 from .thermostat_ensto import EnstoThermostat  # noqa: F401
 from .voltage_bm2 import VoltageTesterBM2  # noqa: F401
 from .vson_air_wp6003 import VsonWP6003  # noqa: F401

--- a/ble2mqtt/devices/ruuvitag.py
+++ b/ble2mqtt/devices/ruuvitag.py
@@ -79,3 +79,58 @@ class RuuviTag(SubscribeAndSetDataMixin, Sensor):
                 f'Advert received for {self}, {format_binary(raw_data)}, '
                 f'current state: {self._state}',
             )
+
+class RuuviTagPro2in1(RuuviTag):
+    NAME = 'ruuvitag_pro_2in1'
+
+    @property
+    def entities(self):
+        return {
+            SENSOR_DOMAIN: [
+                {
+                    'name': 'temperature',
+                    'device_class': 'temperature',
+                    'unit_of_measurement': '\u00b0C',
+                },
+                {
+                    'name': 'movement_counter',
+                    'device_class': 'count',
+                },
+                {
+                    'name': 'battery',
+                    'device_class': 'battery',
+                    'unit_of_measurement': '%',
+                    'entity_category': 'diagnostic',
+                },
+            ],
+        }
+
+class RuuviTagPro3in1(RuuviTag):
+    NAME = 'ruuvitag_pro_3in1'
+
+    @property
+    def entities(self):
+        return {
+            SENSOR_DOMAIN: [
+                {
+                    'name': 'temperature',
+                    'device_class': 'temperature',
+                    'unit_of_measurement': '\u00b0C',
+                },
+                {
+                    'name': 'humidity',
+                    'device_class': 'humidity',
+                    'unit_of_measurement': '%',
+                },
+                {
+                    'name': 'movement_counter',
+                    'device_class': 'count',
+                },
+                {
+                    'name': 'battery',
+                    'device_class': 'battery',
+                    'unit_of_measurement': '%',
+                    'entity_category': 'diagnostic',
+                },
+            ],
+        }


### PR DESCRIPTION
I'm not sure how to achieve this.  How can I make the set of entities more dynamic.  My attempt has resulted in:

Traceback (most recent call last):
  File "/usr/bin/ble2mqtt", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/python3.11/site-packages/ble2mqtt/__main__.py", line 171, in main
  File "/usr/lib/python3.11/asyncio/runners.py", line 190, in run
  File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
  File "/usr/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
  File "/usr/lib/python3.11/site-packages/ble2mqtt/__main__.py", line 127, in amain
  File "/usr/lib/python3.11/site-packages/ble2mqtt/ble2mqtt.py", line 95, in register
  File "/usr/lib/python3.11/site-packages/ble2mqtt/devices/base.py", line 504, in __init__
  File "/usr/lib/python3.11/site-packages/ble2mqtt/devices/base.py", line 210, in __init__
  File "/usr/lib/python3.11/site-packages/ble2mqtt/devices/ruuvitag.py", line 50, in entities
    if self._state.humidity:
       ^^^^^^^^^^^
AttributeError: 'RuuviTag' object has no attribute '_state'

I'm trying to avoid warnings from Home Assistant:
WARNING (MainThread) [homeassistant.helpers.template] Template variable warning: 'dict object' has no attribute 'pressure' when rendering '{{ value_json.pressure }}'