### PR TITLE
devices/base: allow override of all passive sleep intervals

### DIFF
--- a/ble2mqtt/devices/base.py
+++ b/ble2mqtt/devices/base.py
@@ -188,7 +188,8 @@ class Device(BaseDevice, abc.ABC):
     CONNECTION_FAILURES_LIMIT = 100
     RECONNECTION_SLEEP_INTERVAL = 60
     ACTIVE_SLEEP_INTERVAL = 60
-    PASSIVE_SLEEP_INTERVAL = 60
+    DEFAULT_PASSIVE_SLEEP_INTERVAL = 60
+    PASSIVE_SLEEP_INTERVAL = DEFAULT_PASSIVE_SLEEP_INTERVAL
     # deprecated
     LINKQUALITY_TOPIC: ty.Optional[str] = None
     STATE_TOPIC: str = DEFAULT_STATE_TOPIC
@@ -200,6 +201,7 @@ class Device(BaseDevice, abc.ABC):
         super().__init__(*args, **kwargs)
         self.message_queue: aio.Queue = aio.Queue(**get_loop_param(self._loop))
         self.mac = mac.lower()
+        self.PASSIVE_SLEEP_INTERVAL = int(kwargs.pop('interval', self.DEFAULT_PASSIVE_SLEEP_INTERVAL))
         self.friendly_name = kwargs.pop('friendly_name', None)
         self._model = None
         self._version = None

--- a/ble2mqtt/devices/presence.py
+++ b/ble2mqtt/devices/presence.py
@@ -27,7 +27,7 @@ class Presence(Sensor):
     SUPPORT_ACTIVE = False
     MANUFACTURER = 'Generic'
     THRESHOLD = 300  # if no activity more than THRESHOLD, consider presence=OFF
-    PASSIVE_SLEEP_INTERVAL = 1
+    DEFAULT_PASSIVE_SLEEP_INTERVAL = 1
     SEND_DATA_PERIOD = 60
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Sometimes sensor devices are placed in areas where the temperature and/or humidity change rapidly and so a smaller interval than 60s would be preferred.  This change makes it possible to change the intervals for all passive devices using the interval key (already supported for certain devices).  It is an open question whether the same change should be made for active only devices too.