### PR TITLE
Add Govee H5074 temperature/humidity sensor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 - **RuuviTag Pro 2in1 (type: ruuvitag_pro_2in1)**
 - **RuuviTag Pro 3in1 (type: ruuvitag_pro_3in1)**
 - **RuuviTag Pro 4in1 (type: ruuvitag)**
+- **Govee H5074 (type: govee)**
 
 ### Air sensors
 - **Vson WP6003 (type: wp6003)**
@@ -96,6 +97,7 @@ To use connection to the device provide `"passive": false` parameter.
 - Xiaomi MJ_HT_V1 (xiaomihtv1)
 - Xiaomi LYWSD03MMC with custom ATC firmware (xiaomilywsd_atc)
 - RuuviTag (ruuvitag/ruuvitag_pro_2in1/ruuvitag_pro_3in1)
+- Govee (govee)
 - Any device as presence tracker
 
 ## Manual pairing in Linux

--- a/ble2mqtt/devices/__init__.py
+++ b/ble2mqtt/devices/__init__.py
@@ -6,6 +6,7 @@ from .cover_am43 import AM43Cover  # noqa: F401
 from .cover_soma import SomaCover  # noqa: F401
 from .flower_mclh09 import FlowerMonitorMCLH09  # noqa: F401
 from .flower_miflora import FlowerMonitorMiFlora  # noqa: F401
+from .govee import GoveeTemperature  # noqa: F401
 from .kettle_redmond import RedmondKettle  # noqa: F401
 from .kettle_xiaomi import XiaomiKettle  # noqa: F401
 from .presence import Presence  # noqa: F401

--- a/ble2mqtt/devices/govee.py
+++ b/ble2mqtt/devices/govee.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 
 from bleak.backends.device import BLEDevice
 
-from ..devices.base import Sensor, SENSOR_DOMAIN, SubscribeAndSetDataMixin
+from ..devices.base import Sensor, SENSOR_DOMAIN
 from ..protocols.govee import GoveeDecoder
 from ..utils import format_binary
 
@@ -17,7 +17,7 @@ class SensorState:
     humidity: float = 0
 
 
-class GoveeTemperature(SubscribeAndSetDataMixin, Sensor):
+class GoveeTemperature(Sensor):
     NAME = 'govee'
     SENSOR_CLASS = SensorState
     SUPPORT_PASSIVE = True

--- a/ble2mqtt/devices/govee.py
+++ b/ble2mqtt/devices/govee.py
@@ -1,0 +1,69 @@
+import logging
+from dataclasses import dataclass
+
+from bleak.backends.device import BLEDevice
+
+from ..devices.base import Sensor, SENSOR_DOMAIN, SubscribeAndSetDataMixin
+from ..protocols.govee import GoveeDecoder
+from ..utils import format_binary
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class SensorState:
+    battery: int = 0
+    temperature: float = 0
+    humidity: float = 0
+
+
+class GoveeTemperature(SubscribeAndSetDataMixin, Sensor):
+    NAME = 'govee'
+    SENSOR_CLASS = SensorState
+    SUPPORT_PASSIVE = True
+    SUPPORT_ACTIVE = False
+    REQUIRED_VALUES = ('temperature', 'humidity')
+
+    @property
+    def entities(self):
+        return {
+            SENSOR_DOMAIN: [
+                {
+                    'name': 'temperature',
+                    'device_class': 'temperature',
+                    'unit_of_measurement': '\u00b0C',
+                },
+                {
+                    'name': 'humidity',
+                    'device_class': 'humidity',
+                    'unit_of_measurement': '%',
+                },
+                {
+                    'name': 'battery',
+                    'device_class': 'battery',
+                    'unit_of_measurement': '%',
+                    'entity_category': 'diagnostic',
+                },
+            ],
+        }
+
+    def handle_advert(self, scanned_device: BLEDevice, adv_data):
+        raw_data = adv_data.manufacturer_data.get(0xec88)
+        if not raw_data:
+            _LOGGER.debug(f'Temperature data not found; got {repr(adv_data.manufacturer_data)}')
+            return
+
+        if len(raw_data) != 7:
+            _LOGGER.debug(f'Unexpected raw data length {len(raw_data)} ({repr(raw_data)})')
+
+        decoder = GoveeDecoder(bytes(raw_data))
+        self._state = self.SENSOR_CLASS(
+            temperature=decoder.temperature_celsius,
+            humidity=decoder.humidity_percentage,
+            battery=decoder.battery_percentage,
+        )
+
+        _LOGGER.debug(
+            f'Advert received for {self}, {format_binary(raw_data)}, '
+            f'current state: {self._state}',
+        )

--- a/ble2mqtt/protocols/govee.py
+++ b/ble2mqtt/protocols/govee.py
@@ -22,9 +22,9 @@ class GoveeDecoder:
 
     @property
     def humidity_percentage(self) -> float | None:
-        if self.data[1] == 65535:
+        if self.data[0] == -32768:
             return None
-        return round(self.data[1] / 200.0, 2)
+        return round(self.data[1] / 100.0, 2)
 
     @property
     def battery_percentage(self) -> int | None:

--- a/ble2mqtt/protocols/govee.py
+++ b/ble2mqtt/protocols/govee.py
@@ -4,7 +4,6 @@ Based on https://github.com/wcbonner/GoveeBTTempLogger/blob/master/goveebttemplo
 """
 from __future__ import annotations
 
-import math
 import struct
 
 

--- a/ble2mqtt/protocols/govee.py
+++ b/ble2mqtt/protocols/govee.py
@@ -1,5 +1,5 @@
 """
-Decoder for Govee H5074 temperature/humidity sensor.
+Decoder for Govee temperature/humidity sensors.
 Based on https://github.com/wcbonner/GoveeBTTempLogger/blob/master/goveebttemplogger.cpp (MIT License)
 """
 from __future__ import annotations
@@ -10,6 +10,7 @@ import struct
 
 class GoveeDecoder:
     def __init__(self, raw_data: bytes) -> None:
+        # note: currently only H5074 is supported
         if len(raw_data) != 7:
             raise ValueError("Govee data must be 7 bytes long")
         self.data: tuple[int, ...] = struct.unpack("<xhhBx", raw_data)

--- a/ble2mqtt/protocols/govee.py
+++ b/ble2mqtt/protocols/govee.py
@@ -1,0 +1,31 @@
+"""
+Decoder for Govee H5074 temperature/humidity sensor.
+Based on https://github.com/wcbonner/GoveeBTTempLogger/blob/master/goveebttemplogger.cpp (MIT License)
+"""
+from __future__ import annotations
+
+import math
+import struct
+
+
+class GoveeDecoder:
+    def __init__(self, raw_data: bytes) -> None:
+        if len(raw_data) != 7:
+            raise ValueError("Govee data must be 7 bytes long")
+        self.data: tuple[int, ...] = struct.unpack("<xhhBx", raw_data)
+
+    @property
+    def temperature_celsius(self) -> float | None:
+        if self.data[0] == -32768:
+            return None
+        return round(self.data[0] / 100.0, 2)
+
+    @property
+    def humidity_percentage(self) -> float | None:
+        if self.data[1] == 65535:
+            return None
+        return round(self.data[1] / 200.0, 2)
+
+    @property
+    def battery_percentage(self) -> int | None:
+        return self.data[2]


### PR DESCRIPTION
Add support for Govee H5074 temperature/humidity sensor. There are other Govee sensors with similar protocols supported by various other implementations, but I don't have any of them to test with so I haven't included them here.