### PR TITLE
Cleanup inheritance for passive temperature and humidity sensors

### DIFF
--- a/ble2mqtt/devices/base.py
+++ b/ble2mqtt/devices/base.py
@@ -189,7 +189,6 @@ class Device(BaseDevice, abc.ABC):
     RECONNECTION_SLEEP_INTERVAL = 60
     ACTIVE_SLEEP_INTERVAL = 60
     DEFAULT_PASSIVE_SLEEP_INTERVAL = 60
-    PASSIVE_SLEEP_INTERVAL = DEFAULT_PASSIVE_SLEEP_INTERVAL
     # deprecated
     LINKQUALITY_TOPIC: ty.Optional[str] = None
     STATE_TOPIC: str = DEFAULT_STATE_TOPIC
@@ -201,7 +200,7 @@ class Device(BaseDevice, abc.ABC):
         super().__init__(*args, **kwargs)
         self.message_queue: aio.Queue = aio.Queue(**get_loop_param(self._loop))
         self.mac = mac.lower()
-        self.PASSIVE_SLEEP_INTERVAL = int(
+        self.passive_sleep_interval = int(
             kwargs.pop('interval', self.DEFAULT_PASSIVE_SLEEP_INTERVAL),
         )
         self._suggested_area = kwargs.pop('suggested_area', None)
@@ -582,7 +581,7 @@ class Sensor(Device, abc.ABC):
 
             await self.update_device_data(send_config)
             await self.do_passive_loop(publish_topic)
-            await aio.sleep(self.PASSIVE_SLEEP_INTERVAL)
+            await aio.sleep(self.passive_sleep_interval)
 
     async def handle(self, *args, **kwargs):
         if self.is_passive:

--- a/ble2mqtt/devices/base.py
+++ b/ble2mqtt/devices/base.py
@@ -5,6 +5,7 @@ import logging
 import typing as ty
 import uuid
 from collections import defaultdict, namedtuple
+from dataclasses import dataclass
 from enum import Enum
 
 from bleak import BleakClient, BleakError
@@ -587,6 +588,41 @@ class Sensor(Device, abc.ABC):
         if self.is_passive:
             return await self.handle_passive(*args, **kwargs)
         return await self.handle_active(*args, **kwargs)
+
+
+@dataclass
+class HumidityTemperatureSensorState:
+    battery: int = 0
+    temperature: float = 0
+    humidity: float = 0
+
+class HumidityTemperatureSensor(Sensor, abc.ABC):
+    SENSOR_CLASS = HumidityTemperatureSensorState
+    # send data only if temperature or humidity is set
+    REQUIRED_VALUES = ('temperature', 'humidity')
+
+    @property
+    def entities(self):
+        return {
+            SENSOR_DOMAIN: [
+                {
+                    'name': 'temperature',
+                    'device_class': 'temperature',
+                    'unit_of_measurement': '\u00b0C',
+                },
+                {
+                    'name': 'humidity',
+                    'device_class': 'humidity',
+                    'unit_of_measurement': '%',
+                },
+                {
+                    'name': 'battery',
+                    'device_class': 'battery',
+                    'unit_of_measurement': '%',
+                    'entity_category': 'diagnostic',
+                },
+            ],
+        }
 
 
 class SubscribeAndSetDataMixin:

--- a/ble2mqtt/devices/govee.py
+++ b/ble2mqtt/devices/govee.py
@@ -1,52 +1,18 @@
 import logging
-from dataclasses import dataclass
 
 from bleak.backends.device import BLEDevice
-
-from ..devices.base import Sensor, SENSOR_DOMAIN
+from ..devices.base import HumidityTemperatureSensor
 from ..protocols.govee import GoveeDecoder
 from ..utils import format_binary
 
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass
-class SensorState:
-    battery: int = 0
-    temperature: float = 0
-    humidity: float = 0
-
-
-class GoveeTemperature(Sensor):
+class GoveeTemperature(HumidityTemperatureSensor):
     NAME = 'govee'
     MANUFACTURER = 'Govee'
-    SENSOR_CLASS = SensorState
     SUPPORT_PASSIVE = True
     SUPPORT_ACTIVE = False
-    REQUIRED_VALUES = ('temperature', 'humidity')
-
-    @property
-    def entities(self):
-        return {
-            SENSOR_DOMAIN: [
-                {
-                    'name': 'temperature',
-                    'device_class': 'temperature',
-                    'unit_of_measurement': '\u00b0C',
-                },
-                {
-                    'name': 'humidity',
-                    'device_class': 'humidity',
-                    'unit_of_measurement': '%',
-                },
-                {
-                    'name': 'battery',
-                    'device_class': 'battery',
-                    'unit_of_measurement': '%',
-                    'entity_category': 'diagnostic',
-                },
-            ],
-        }
 
     def handle_advert(self, scanned_device: BLEDevice, adv_data):
         raw_data = adv_data.manufacturer_data.get(0xec88)

--- a/ble2mqtt/devices/ruuvitag.py
+++ b/ble2mqtt/devices/ruuvitag.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 
 from bleak.backends.device import BLEDevice
 
-from ..devices.base import Sensor, SENSOR_DOMAIN, SubscribeAndSetDataMixin
+from ..devices.base import Sensor, SENSOR_DOMAIN
 from ..protocols.ruuvi import DataFormat5Decoder
 from ..utils import format_binary, cr2477_voltage_to_percent
 

--- a/ble2mqtt/devices/xiaomi_lywsd03_atc.py
+++ b/ble2mqtt/devices/xiaomi_lywsd03_atc.py
@@ -1,25 +1,17 @@
 import logging
-from dataclasses import dataclass
 
 from bleak.backends.device import BLEDevice
 
 from ..utils import format_binary
 from .uuids import ENVIRONMENTAL_SENSING
-from .xiaomi_base import XiaomiHumidityTemperature
+from .base import HumidityTemperatureSensor
 
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass
-class SensorState:
-    battery: int = 0
-    temperature: float = 0
-    humidity: float = 0
-
-
-class XiaomiHumidityTemperatureLYWSDATC(XiaomiHumidityTemperature):
+class XiaomiHumidityTemperatureLYWSDATC(HumidityTemperatureSensor):
     NAME = 'xiaomilywsd_atc'
-    SENSOR_CLASS = SensorState
+    MANUFACTURER = 'Xiaomi'
     SUPPORT_PASSIVE = True
     SUPPORT_ACTIVE = False
 

--- a/ble2mqtt/devices/xiaomi_lywsd03_atc.py
+++ b/ble2mqtt/devices/xiaomi_lywsd03_atc.py
@@ -15,7 +15,6 @@ class SensorState:
     battery: int = 0
     temperature: float = 0
     humidity: float = 0
-    sends_custom: bool = False  # support decimal value for humidity
 
 
 class XiaomiHumidityTemperatureLYWSDATC(XiaomiHumidityTemperature):
@@ -24,15 +23,18 @@ class XiaomiHumidityTemperatureLYWSDATC(XiaomiHumidityTemperature):
     SUPPORT_PASSIVE = True
     SUPPORT_ACTIVE = False
 
+    def __init__(self, mac, *args, **kwargs) -> None:
+        super().__init__(mac, *args, **kwargs)
+        self._sends_custom = False  # support decimal value for humidity
+
     def handle_advert(self, scanned_device: BLEDevice, adv_data):
         service_data = adv_data.service_data
         adv_data = service_data.get(str(ENVIRONMENTAL_SENSING))
 
         if adv_data:
-            sends_custom = bool(self._state and self._state.sends_custom)
             if len(adv_data) == 15:
                 # b'\xe6o\xb98\xc1\xa4\x95\t\xff\x08~\x0cd\xe0\x04'
-                sends_custom = True
+                self._sends_custom = True
                 adv_data = bytes(adv_data)
                 self._state = self.SENSOR_CLASS(
                     temperature=int.from_bytes(
@@ -40,11 +42,10 @@ class XiaomiHumidityTemperatureLYWSDATC(XiaomiHumidityTemperature):
                     humidity=int.from_bytes(
                         adv_data[8:10], byteorder='little') / 100,
                     battery=adv_data[12],
-                    sends_custom=sends_custom,
                 )
 
             elif len(adv_data) == 13:
-                if sends_custom:
+                if self._sends_custom:
                     # ignore low res humidity packets
                     return
                 # [a4 c1 38 84 7e 97 01 26 15 50 0b 73 17]
@@ -55,7 +56,6 @@ class XiaomiHumidityTemperatureLYWSDATC(XiaomiHumidityTemperature):
                         adv_data[6:8], byteorder='big', signed=True) / 10,
                     humidity=adv_data[8],
                     battery=adv_data[9],
-                    sends_custom=sends_custom,
                 )
                 _LOGGER.debug(
                     f'Advert received for {self}, {format_binary(adv_data)}, '


### PR DESCRIPTION
Plus two small further cleanups.

Tested and it seems to work: 
INFO: [Xiaomi_ATC_0A45ED_Nook] send state=HumidityTemperatureSensorState(battery=100, temperature=19.72, humidity=52.23)

Unfortunately I couldn't plug this into the inheritance hierachy of XiaomiHumidityTemperature without making XiaomiPoller less general.
