### PR TITLE
ruuvitag: remove device class for counter

### DIFF
--- a/ble2mqtt/devices/ruuvitag.py
+++ b/ble2mqtt/devices/ruuvitag.py
@@ -49,7 +49,6 @@ class RuuviTag(Sensor):
                 },
                 {
                     'name': 'movement_counter',
-                    'device_class': 'count',
                 },
                 {
                     'name': 'battery',


### PR DESCRIPTION
This gives an error in the logs.  When implementing this I confused https://github.com/home-assistant/core/blob/d47ec9123153c6a8cc5d3644956b82e82bca8458/homeassistant/components/sensor/const.py#L70 and
https://github.com/Bluetooth-Devices/sensor-state-data/blob/9ed2d0b586d4bcc93574d9de0cf5e0974509760e/src/sensor_state_data/sensor/device_class.py#L6 the latter used in the built in component handling of RuuviTags in Home Assistant the former in the Home Assistant MQTT component.