### PR TITLE
compat: cache Bleak version

### DIFF
--- a/ble2mqtt/compat.py
+++ b/ble2mqtt/compat.py
@@ -20,8 +20,10 @@ def get_bleak_version():
     return metadata.version('bleak')
 
 
+bleak_version = get_bleak_version()
+
+
 def get_scanner(hci_adapter: str, detection_callback) -> bleak.BleakScanner:
-    bleak_version = get_bleak_version()
     if bleak_version and bleak_version < '0.18':
         scanner = bleak.BleakScanner(adapter=hci_adapter)
         scanner.register_detection_callback(detection_callback)


### PR DESCRIPTION
The get_bleak_version call leads to opening a file to get the version. This is fairly redundant as the Bleak version will be stable for the lifetime of the process. Moreover it seems to trigger a small memory leak according to tracemalloc:

/usr/lib64/python3.12/pathlib.py:1013: size=708 B (+59 B), count=12 (+1), average=59 B
/usr/lib64/python3.12/pathlib.py:1013: size=767 B (+59 B), count=13 (+1), average=59 B

So cache the value of the function to avoid a file access and a memory leak.

<details>
<summary>Stacktrace of call to pathlib</summary>

```
  File "/usr/lib64/python3.12/asyncio/events.py", line 88
    self._context.run(self._callback, *self._args)
  File "<venv>/lib64/python3.12/site-packages/ble2mqtt/ble2mqtt.py", line 208
    scanner = get_scanner(
  File "<venv>/lib64/python3.12/site-packages/ble2mqtt/compat.py", line 24
    bleak_version = get_bleak_version()
  File "<venv>/lib64/python3.12/site-packages/ble2mqtt/compat.py", line 20
    return metadata.version('bleak')
  File "/usr/lib64/python3.12/importlib/metadata/__init__.py", line 889
    return distribution(distribution_name).version
  File "/usr/lib64/python3.12/importlib/metadata/__init__.py", line 467
    return self.metadata['Version']
  File "/usr/lib64/python3.12/importlib/metadata/__init__.py", line 444
    self.read_text('METADATA')
  File "/usr/lib64/python3.12/importlib/metadata/__init__.py", line 819
    return self._path.joinpath(filename).read_text(encoding='utf-8')
  File "/usr/lib64/python3.12/pathlib.py", line 1027
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
  File "/usr/lib64/python3.12/pathlib.py", line 1013
    return io.open(self, mode, buffering, encoding, errors, newline)
```
   </details>