### PR TITLE
Correct library main function

### DIFF
--- a/ble2mqtt/__main__.py
+++ b/ble2mqtt/__main__.py
@@ -111,6 +111,7 @@ async def amain(config):
         base_topic=config['base_topic'],
         mqtt_config_prefix=config['mqtt_config_prefix'],
         hci_adapter=config['hci_adapter'],
+        legacy_color_mode=config['legacy_color_mode'],
     )
 
     loop.set_exception_handler(


### PR DESCRIPTION
# Description

https://github.com/devbis/ble2mqtt/pull/96 updated the python package version information. I found that when starting it from the command line after installing the python package I got the following error:

```
  File "/home/<user>/.local/pipx/venvs/ble2mqtt/lib/python3.11/site-packages/ble2mqtt/__main__.py", line 103, in amain
    service = Ble2Mqtt(
              ^^^^^^^^^
TypeError: Ble2Mqtt.__init__() missing 1 required keyword-only argument: 'legacy_color_mode'
```

https://github.com/devbis/ble2mqtt/commit/de961f85ab175f53b583cfe335a87a961b25e952 added a new argument which wasn't not included when calling `amain`.

# Changes
* Add missing argument